### PR TITLE
Fix pandas import in tests

### DIFF
--- a/tests/test_module_user/test_routes.py
+++ b/tests/test_module_user/test_routes.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 from flask_testing import TestCase
 from app import create_app
-import Pandas as pd
+import pandas as pd
 
 class TestFlaskRoutes(TestCase):
     def create_app(self):


### PR DESCRIPTION
## Summary
- fix pandas import case in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_testing')*

------
https://chatgpt.com/codex/tasks/task_e_684022e803508323973be4986f8990e6