### PR TITLE
Fix confidence_scores else branch

### DIFF
--- a/app/module_model/model.py
+++ b/app/module_model/model.py
@@ -60,7 +60,7 @@ def make_predictions(H, model_path):
         confidence_scores = np.around(confidence_scores, decimals=3)
     else:
         # If no confidence information is available, return None
-        confidence_scores = Noneconfidence_scores = None
+        confidence_scores = None
 
     logging.info("Predictions completed successfully.")
 


### PR DESCRIPTION
## Summary
- fix incorrect `confidence_scores` assignment in model prediction logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask_testing, flask, numpy, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6840230620308323afe731fa89020a33