### PR TITLE
Fix assertion call for path existence test

### DIFF
--- a/tests/test_module_model/test_model.py
+++ b/tests/test_module_model/test_model.py
@@ -18,7 +18,7 @@ def test_make_predictions_success():
         
         predictions, confidence_scores, input_data = make_predictions(H, model_path)
 
-        assert mock_exists.called_with(os.path.join(os.getcwd(), model_path))
+        mock_exists.assert_called_with(os.path.join(os.getcwd(), model_path))
         assert predictions is not None
         assert confidence_scores is not None
         assert np.array_equal(input_data, H)


### PR DESCRIPTION
## Summary
- update model path existence assertion to use `assert_called_with`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_testing')*

------
https://chatgpt.com/codex/tasks/task_e_6840231cdeec832386332255dade8083